### PR TITLE
Unclip data table and map teams to fixtures

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -311,7 +311,6 @@ body {
 @media (min-width: 768px) {
   .gameweek-tile {
     padding: var(--space-4) var(--space-5);
-    height: 550px;
   }
 }
 

--- a/app/components/data-table.tsx
+++ b/app/components/data-table.tsx
@@ -18,9 +18,17 @@ import { ArrowUpDown, ChevronLeft, ChevronRight } from "lucide-react"
 import { Button } from "../components/ui/button"
 import type { Players } from '~/types'
 import { TeamChip } from "./top-performers"
+import { teamAbbreviations } from "~/lib/team-abbreviations"
+import type { TeamFixture } from "./gameweek-tile"
 
+function abbr(team: string) {
+    return teamAbbreviations[team] || team.substring(0, 3).toUpperCase();
+}
 
-export const columns: ColumnDef<Players>[] = [
+export function buildColumns(teamFixtures: Map<string, TeamFixture>): ColumnDef<Players>[] {
+    const hasFixtures = teamFixtures.size > 0;
+
+    return [
     {
         accessorKey: "player_name",
         header: "Player",
@@ -49,7 +57,27 @@ export const columns: ColumnDef<Players>[] = [
             </Button>
         ),
     },
-    { accessorKey: "team", header: "Team" },
+    {
+        accessorKey: "team",
+        header: hasFixtures ? "Fixture" : "Team",
+        cell: ({ row }) => {
+            const team = row.original.team;
+            const fixture = teamFixtures.get(team);
+            if (!fixture) {
+                return <span>{team}</span>;
+            }
+            return (
+                <span className="font-mono text-xs whitespace-nowrap">
+                    <span className="text-text-primary">{abbr(team)}</span>
+                    <span className="text-text-secondary"> {fixture.isHome ? 'vs' : '@'} </span>
+                    <span className="text-text-primary">{abbr(fixture.opponent)}</span>
+                    <span className={`ml-1 text-[0.6rem] ${fixture.isHome ? 'text-gold' : 'text-text-secondary'}`}>
+                        ({fixture.isHome ? 'H' : 'A'})
+                    </span>
+                </span>
+            );
+        },
+    },
     {
         accessorKey: "expected_assists",
         header: ({ column }) => (
@@ -135,7 +163,10 @@ export const columns: ColumnDef<Players>[] = [
     { accessorKey: "goals_scored", header: "GS" },
     { accessorKey: "tackles", header: "Tkl" },
     { accessorKey: "yellow_cards", header: "YC" },
-]
+    ];
+}
+
+export const columns: ColumnDef<Players>[] = buildColumns(new Map());
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<Players, TValue>[]

--- a/app/components/gameweek-tile.tsx
+++ b/app/components/gameweek-tile.tsx
@@ -1,532 +1,145 @@
 import { getFixturesData, getGameweekData } from "~/data";
-import {type Fixtures, type Players, type Season } from "~/types";
-import { useCallback, useEffect, useState } from "react";
-import { columns, DataTable } from "./data-table";
+import { type Fixtures, type Players, type Season } from "~/types";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { buildColumns, DataTable } from "./data-table";
 import { useIsMobile } from "~/components/ui/use-mobile";
 import { teamAbbreviations } from "~/lib/team-abbreviations";
 import { PlayerChartsDashboard } from "./player-dashboard";
 import { TeamChartsDashboard } from "./team-dashboard";
 import { TopPerformers } from "./top-performers";
 
-
 interface gameweekTileProps {
-
-
-
     gameweek: number,
-
-
-
     season: Season
-
-
-
 }
 
+export type TeamFixture = {
+    opponent: string;
+    isHome: boolean;
+    finished: boolean;
+};
 
-
-
-
-
-
-const TopExpectedAssists = (players:Players[]) => {
-
-
-
-    const filteredPlayers = players.sort((a, b) => Number(b.expected_assists) - Number(a.expected_assists))
-
-
-
-        .slice(0, 2);
-
-
-
-    
-
-
-
-        return filteredPlayers;
-
-
-
-    };
-
-
-
-
-
-
-
-
-
-
+export function buildTeamFixtureMap(fixtures: Fixtures[] | undefined): Map<string, TeamFixture> {
+    const map = new Map<string, TeamFixture>();
+    if (!fixtures) return map;
+    for (const f of fixtures) {
+        map.set(f.home, { opponent: f.away, isHome: true, finished: f.finished });
+        map.set(f.away, { opponent: f.home, isHome: false, finished: f.finished });
+    }
+    return map;
+}
 
 export function GameweekTile({ gameweek, season }: gameweekTileProps) {
+    const [data, setData] = useState<Players[]>([]);
+    const [fixtures, setFixtures] = useState<Fixtures[] | undefined>();
 
-
-
-    const [ data, setData ]  = useState<Players[]>([{
-
-
-
-        player_id: 0,
-
-
-
-        bonus: 0,
-
-
-
-        bps: 0,
-
-
-
-        clean_sheets: 0,
-
-
-
-        clearances_blocks_interceptions: 0,
-
-
-
-        creativity: "1",
-
-
-
-        defensive_contribution: 0,
-
-
-
-        expected_assists: "1",
-
-
-
-        expected_goal_involvements: "1", 
-
-
-
-        expected_goals: "1",
-
-
-
-        expected_goals_conceded: "1",
-
-
-
-        gameweek: 0,
-
-
-
-        goals_conceded: 0,
-
-
-
-        goals_scored: 0,
-
-
-
-        ict_index: "1",
-
-
-
-        in_dreamteam: 0,
-
-
-
-        index: 0,
-
-
-
-        influence: "1",
-
-
-
-        minutes: 0,
-
-
-
-        own_goals: 0,
-
-
-
-        penalties_missed: 0,
-
-
-
-        penalties_saved: 0,
-
-
-
-        player_name: "1",
-
-
-
-        position: "1",
-
-
-
-        recoveries: 0,
-
-
-
-        red_cards: 0,
-
-
-
-        saves: 0,
-
-
-
-        starts: 0,
-
-
-
-        tackles: 0,
-
-
-
-        team: "1", 
-
-
-
-        threat: "1",
-
-
-
-        total_points: 0,
-
-
-
-        yellow_cards: 0,
-
-
-
-    }]);
-
-
-
-
-
-
-
-    const gameweekData = useCallback( async () => {
-
-
-
+    const gameweekData = useCallback(async () => {
         try {
-
-
-
-            const response = await getGameweekData(gameweek, season)
-
-
-
-        setData(response as Players[]);
-
-
-
-        } catch(e) {
-
-
-
+            const response = await getGameweekData(gameweek, season);
+            setData(response as Players[]);
+        } catch (e) {
             console.log(e);
-
-
-
             throw new Error("Error fetching data");
-
-
-
         }
+    }, [gameweek, season]);
 
+    const fixtureData = useCallback(async () => {
+        try {
+            const response = await getFixturesData(gameweek, season);
+            setFixtures(response as Fixtures[]);
+        } catch (e) {
+            console.log(e);
+            setFixtures(undefined);
+        }
+    }, [gameweek, season]);
 
-
-    }, [gameweek]);
-
-
-
-
-
-
-
-    useEffect(() =>{
-
-
-
+    useEffect(() => {
         gameweekData();
+        fixtureData();
+    }, [season, gameweek]);
 
-
-
-    },  [season, gameweek]);
-
-
-
-
-
-
-
-    
-
-
+    const teamFixtures = useMemo(() => buildTeamFixtureMap(fixtures), [fixtures]);
+    const columns = useMemo(() => buildColumns(teamFixtures), [teamFixtures]);
 
     if (!data) {
-
-
-
-        return
-
-
-
-      }
-
-
+        return;
+    }
 
     return (
-
-
         <>
-        <div className="gameweek-tile w-full max-w-full">
-            <div className="fixture-tile-wrapper">
-                <FixtureTile key={gameweek+1} gameweek={gameweek} season={season}></FixtureTile>
-            </div>
+            <div className="gameweek-tile w-full max-w-full">
+                <div className="fixture-tile-wrapper">
+                    <FixtureTile fixtures={fixtures} />
+                </div>
                 <TopPerformers data={data} />
                 <DataTable columns={columns} data={data} />
-        </div>
-
-        {data && <div className="w-full max-w-full overflow-x-hidden">
-        <PlayerChartsDashboard data={data} />
-        <TeamChartsDashboard data={data} />
-
-        </div>}
-        </>
-
-
-
-    );
-
-
-
-}
-
-
-
-
-
-
-
-export function FixtureTile({gameweek, season}: gameweekTileProps) {
-
-
-
-    const isMobile = useIsMobile();
-
-
-
-    const [ data, setData ]  = useState<Fixtures[] | undefined>();
-
-
-
-
-    const fixtureData = useCallback( async () => {
-
-
-
-        try {
-
-
-
-        const response = await getFixturesData(gameweek, season)
-
-
-
-        setData(response as Fixtures[]);
-
-
-
-
-
-
-
-        } catch(e) {
-
-
-
-            console.log(e)
-
-
-
-            throw new Error("Error fetching data");
-
-
-
-        }
-
-
-
-    }, [season]);
-
-
-
-
-
-
-
-    useEffect(() =>{
-
-
-        ///Prefer useQuery
-        fixtureData();
-
-
-
-    },  [season, gameweek]);
-
-
-
-
-
-
-
-    
-
-
-
-    if (!data) {
-
-
-
-        return
-
-
-
-      }
-
-
-
-    return (
-
-
-
-        <div className="px-2 md:px-12 justify-between fixture-tile">
-
-
-
-                {   
-
-
-
-                    data.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()).map((item, index, ) => {
-
-
-
-
-
-
-
-                        const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-
-
-                        const tempDate = new Intl.DateTimeFormat('en-UK', {
-
-
-
-                            timeZone: userTimezone,
-
-
-
-                            weekday: 'short',
-
-
-
-                            hour: 'numeric',   
-
-
-
-                            minute: '2-digit',
-
-
-
-                            hour12: false 
-
-
-
-                        }).format(new Date(item.date));
-
-
-
-
-
-
-
-                        const homeWin: Boolean = item.homegoals > item.awaygoals ;
-
-
-
-                        const draw: Boolean = item.homegoals == item.awaygoals;
-
-
-
-
-
-
-
-                        return (
-
-
-                            <div key={index} className="flex items-center justify-between gap-2 px-3 py-2 rounded-none bg-surface-2 border border-gold-subtle hover:border-gold-muted transition-all duration-200 text-text-primary">
-
-                                {/* Date */}
-                                <span className="text-[0.6rem] font-mono font-normal text-text-secondary w-10 shrink-0">
-                                {tempDate}
-                                </span>
-
-                                {/* Home Team */}
-                                <span className={`text-xs font-mono truncate text-right w-20 shrink-0 ${
-                                draw ? 'font-normal opacity-60' : homeWin ? 'font-semibold text-gold' : 'font-normal opacity-60'
-                                }`}>
-                                {isMobile ? teamAbbreviations[item.home] || item.home.substring(0, 3).toUpperCase() : item.home}
-                                </span>
-
-                                {/* Score */}
-                                <span className={`text-xs font-mono font-bold px-2 py-0.5 rounded shrink-0 ${
-                                item.finished ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' : 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
-                                }`}>
-                                {item.homegoals} – {item.awaygoals}
-                                </span>
-
-                                {/* Away Team */}
-                                <span className={`text-xs font-mono truncate text-left w-20 shrink-0 ${
-                                draw ? 'font-normal opacity-60' : !homeWin ? 'font-semibold text-gold' : 'font-normal opacity-60'
-                                }`}>
-                                {isMobile ? teamAbbreviations[item.away] || item.away.substring(0, 3).toUpperCase() : item.away}
-                                </span>
-
-                                {/* Status pip */}
-                                <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${item.finished ? 'bg-emerald-400' : 'bg-amber-400'}`} />
-
-</div>
-
-
-
-                    )})
-
-
-
-                }
-
-
-
             </div>
 
-
-
-        );
-
-
-
+            {data && <div className="w-full max-w-full overflow-x-hidden">
+                <PlayerChartsDashboard data={data} />
+                <TeamChartsDashboard data={data} />
+            </div>}
+        </>
+    );
 }
 
+interface FixtureTileProps {
+    fixtures: Fixtures[] | undefined;
+}
 
+export function FixtureTile({ fixtures }: FixtureTileProps) {
+    const isMobile = useIsMobile();
 
+    if (!fixtures) {
+        return null;
+    }
 
+    return (
+        <div className="px-2 md:px-12 justify-between fixture-tile">
+            {fixtures
+                .slice()
+                .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+                .map((item, index) => {
+                    const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                    const tempDate = new Intl.DateTimeFormat('en-UK', {
+                        timeZone: userTimezone,
+                        weekday: 'short',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                        hour12: false,
+                    }).format(new Date(item.date));
+
+                    const homeWin: boolean = item.homegoals > item.awaygoals;
+                    const draw: boolean = item.homegoals === item.awaygoals;
+
+                    return (
+                        <div key={index} className="flex items-center justify-between gap-2 px-3 py-2 rounded-none bg-surface-2 border border-gold-subtle hover:border-gold-muted transition-all duration-200 text-text-primary">
+                            <span className="text-[0.6rem] font-mono font-normal text-text-secondary w-10 shrink-0">
+                                {tempDate}
+                            </span>
+
+                            <span className={`text-xs font-mono truncate text-right w-20 shrink-0 ${
+                                draw ? 'font-normal opacity-60' : homeWin ? 'font-semibold text-gold' : 'font-normal opacity-60'
+                            }`}>
+                                {isMobile ? teamAbbreviations[item.home] || item.home.substring(0, 3).toUpperCase() : item.home}
+                            </span>
+
+                            <span className={`text-xs font-mono font-bold px-2 py-0.5 rounded shrink-0 ${
+                                item.finished ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' : 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
+                            }`}>
+                                {item.homegoals} – {item.awaygoals}
+                            </span>
+
+                            <span className={`text-xs font-mono truncate text-left w-20 shrink-0 ${
+                                draw ? 'font-normal opacity-60' : !homeWin ? 'font-semibold text-gold' : 'font-normal opacity-60'
+                            }`}>
+                                {isMobile ? teamAbbreviations[item.away] || item.away.substring(0, 3).toUpperCase() : item.away}
+                            </span>
+
+                            <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${item.finished ? 'bg-emerald-400' : 'bg-amber-400'}`} />
+                        </div>
+                    );
+                })}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Remove the fixed `height: 550px` on `.gameweek-tile` so it grows with content — the data table is no longer clipped on desktop.
- Lift fixture fetching from `FixtureTile` into `GameweekTile` and pass a team→fixture map into the data table. When fixtures are present the Team column renders as `{team} vs/@ {opponent} (H/A)`; when absent it falls back to the plain team name.

## Test plan
- [ ] Load `/?season=2024_2025&gw=38` (finalized data) — confirm the Team column header reads "Fixture" and rows show team + opponent + H/A.
- [ ] Load `/` on current season — confirm data table renders below the top-performer cards without being cut off.
- [ ] Switch gameweeks via sidebar — confirm both fixture marquee and data-table fixture column update together.
- [ ] On a gameweek with no fixtures available, confirm column gracefully falls back to "Team" with plain names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)